### PR TITLE
Fix inability to create further modules

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -29,8 +29,7 @@ module.exports = yeoman.generators.Base.extend({
 
   writing: {
     app: function() {
-      this.basicTemplate = 'src/' + this._.slugify(this.appname) +
-        '.html';
+      this.basicTemplate = 'src/' + this._.slugify(this.appname);
 
       this.copy('_package.json', 'package.json');
       this.copy('_gulpfile.js', 'gulpfile.js');
@@ -41,7 +40,8 @@ module.exports = yeoman.generators.Base.extend({
       this.mkdir('src');
       this.copy('src/_index.js', 'src/index.js');
       this.copy('src/_index.html', 'src/index.html');
-      this.copy('src/_basic-template.html', this.basicTemplate);
+      this.copy('src/_basic-template.html', this.basicTemplate + '.html');
+      this.copy('src/_basic-template.js', this.basicTemplate + '.js');
     }
   },
 

--- a/app/templates/src/_basic-template.js
+++ b/app/templates/src/_basic-template.js
@@ -1,0 +1,17 @@
+import {Component, Template} from 'angular2/angular2';
+
+@Component({
+  selector: '<%= _.slugify(appname) %>'
+})
+
+@Template({
+  url: '<%= _.slugify(appname) %>.html'
+})
+
+export class <%= _.classify(appname) %> {
+
+  constructor() {
+    console.info('<%= _.classify(appname) %> Component Mounted Successfully');
+  }
+
+}

--- a/app/templates/src/_index.html
+++ b/app/templates/src/_index.html
@@ -8,24 +8,21 @@
   </head>
   <body>
 
-    <<%= _.slugify(appname) %>>Loading...</<%= _.slugify(appname) %>>
+    <main>Loading...</main>
 
     <script src="lib/system.js"></script>
     <script src="lib/zone.js"></script>
 
     <script>
       System.config({
-        baseURL: 'lib/',
         paths: {
-          'angular2/*': 'angular2.js',
-          'rx/dist/rx.all': 'rx.all.js',
-          'index': '../index.js'
+          'angular2/*': 'lib/angular2.js',
+          'rx/dist/rx.all': 'lib/rx.all.js',
+          'index': 'index.js'
         }
       });
 
-      System.import('index').then(function(module) {
-        module.main();
-      }, console.log.bind(console));
+      System.import('index');
     </script>
 
   </body>

--- a/app/templates/src/_index.js
+++ b/app/templates/src/_index.js
@@ -1,22 +1,19 @@
 import {Component, Template, bootstrap} from 'angular2/angular2';
-import {bind} from 'angular2/di';
+import {<%= _.classify(appname) %>} from '<%= _.slugify(appname) %>';
 
 @Component({
-  selector: '<%= _.slugify(appname) %>'
+  selector: 'main'
 })
 
 @Template({
-  url: '<%= _.slugify(appname) %>.html'
+  directives: [<%= _.classify(appname) %>],
+  inline: `
+    <<%= _.slugify(appname) %>></<%= _.slugify(appname) %>>
+  `
 })
 
-class <%= _.classify(appname) %> {
-
-  constructor() {
-    console.log('component mounted');
-  }
+class Main {
 
 }
 
-export function main() {
-  bootstrap(<%= _.classify(appname) %>);
-}
+bootstrap(Main);

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -83,9 +83,7 @@ describe('when angular2 generator generates', function() {
 
       it('should create the dynamically named files named correctly', function() {
         assert.file([
-          'src/caseNamed.js',
           'src/casenamed.js',
-          'src/caseNamed.html',
           'src/casenamed.html'
         ]);
       });
@@ -149,9 +147,7 @@ describe('when angular2 generator generates', function() {
 
       it('should create the dynamically named files named correctly', function() {
         assert.file([
-          'src/casedName.js',
           'src/casedname.js',
-          'src/casedName.html',
           'src/casedname.html'
         ]);
       });

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -5,16 +5,19 @@ var assert = require('yeoman-generator').assert;
 var helpers = require('yeoman-generator').test;
 var os = require('os');
 
-describe('angular2:app', function () {
-  before(function (done) {
+describe('when angular2 generator generates', function() {
+
+  before(function(done) {
     helpers.run(path.join(__dirname, '../app'))
-      .inDir(path.join(os.tmpdir(), './temp-test'))
-      .withOptions({ 'skip-install': true })
-      .withArguments('fake-app-name')
+      .inDir(path.join(os.tmpdir(), './foo'))
+      // always skip install in tests
+      .withOptions({
+        'skip-install': true
+      })
       .on('end', done);
   });
 
-  it('creates files', function () {
+  it('should create the required static files', function() {
     assert.file([
       'package.json',
       '.editorconfig',
@@ -22,8 +25,138 @@ describe('angular2:app', function () {
       'readme.md',
       'gulpfile.js',
       'src/index.js',
-      'src/index.html',
-      'src/fake-app-name.html'
+      'src/index.html'
     ]);
   });
+
+  describe('when no arguments are passed through', function() {
+
+    describe('when generation happens in a basic named directory', function() {
+      before(function(done) {
+        helpers.run(path.join(__dirname, '../app'))
+          .inDir(path.join(os.tmpdir(), './basic'))
+          // always skip install in tests
+          .withOptions({
+            'skip-install': true
+          })
+          .on('end', done);
+      });
+
+      it('should create the dynamically named files named correctly', function() {
+        assert.file([
+          'src/basic.js',
+          'src/basic.html'
+        ]);
+      });
+    });
+
+    describe('when generation happens in a dashed named directory', function() {
+      before(function(done) {
+        helpers.run(path.join(__dirname, '../app'))
+          .inDir(path.join(os.tmpdir(), './dash-named'))
+          // always skip install in tests
+          .withOptions({
+            'skip-install': true
+          })
+          .on('end', done);
+      });
+
+      it('should create the dynamically named files named correctly', function() {
+        assert.file([
+          'src/dash-named.js',
+          'src/dash-named.html'
+        ]);
+      });
+    });
+
+    describe('when generation happens in a case named directory', function() {
+      before(function(done) {
+        helpers.run(path.join(__dirname, '../app'))
+          .inDir(path.join(os.tmpdir(), './caseNamed'))
+          // always skip install in tests
+          .withOptions({
+            'skip-install': true
+          })
+          // .withArguments('fake-app-name')
+          .on('end', done);
+      });
+
+      it('should create the dynamically named files named correctly', function() {
+        assert.file([
+          'src/caseNamed.js',
+          'src/casenamed.js',
+          'src/caseNamed.html',
+          'src/casenamed.html'
+        ]);
+      });
+    });
+
+  });
+
+  describe('when arguments are passed through', function() {
+
+    describe('when generation happens with a basic name passed as an argument', function() {
+      before(function(done) {
+        helpers.run(path.join(__dirname, '../app'))
+          .inDir(path.join(os.tmpdir(), './foo'))
+          // always skip install in tests
+          .withOptions({
+            'skip-install': true
+          })
+          .withArguments('basic')
+          .on('end', done);
+      });
+
+      it('should create the dynamically named files named correctly', function() {
+        assert.file([
+          'src/basic.js',
+          'src/basic.html'
+        ]);
+      });
+    });
+
+    describe('when generation happens with a dashed name as an argument', function() {
+      before(function(done) {
+        helpers.run(path.join(__dirname, '../app'))
+          .inDir(path.join(os.tmpdir(), './foo'))
+          // always skip install in tests
+          .withOptions({
+            'skip-install': true
+          })
+          .withArguments('dash-named')
+          .on('end', done);
+      });
+
+      it('should create the dynamically named files named correctly', function() {
+        assert.file([
+          'src/dash-named.js',
+          'src/dash-named.html'
+        ]);
+      });
+    });
+
+    describe('when generation happens with a cased name as an argument', function() {
+      before(function(done) {
+        helpers.run(path.join(__dirname, '../app'))
+          .inDir(path.join(os.tmpdir(), './foo'))
+          // always skip install in tests
+          .withOptions({
+            'skip-install': true
+          })
+          .withArguments('casedName')
+          .on('end', done);
+      });
+
+      it('should create the dynamically named files named correctly', function() {
+        assert.file([
+          'src/casedName.js',
+          'src/casedname.js',
+          'src/casedName.html',
+          'src/casedname.html'
+        ]);
+      });
+    });
+
+  });
+
 });


### PR DESCRIPTION
Currently creating a new module and importing it into `index.js` is broken, this fixes that, allowing users to develop a more separated/clean structure. Also adds more/better tests.